### PR TITLE
Updated to use PHG affiliate links, as TradeDoubler is no longer used by iTunes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Piers Biddlestone - https://github.com/eightytwo
 
 CONTRIBUTORS
 Kevin Renskers - https://github.com/kevinrenskers
+Sam Meadley - https://github.com/sammeadley

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ A library for communicating with the iTunes store.
 
 ## Usage
 ```objective-c
-// Set the Last.fm session info
-[ItunesSearch sharedInstance].partnerId = @"xxx";
-[ItunesSearch sharedInstance].tradeDoublerId = @"xxx";
+// Set the PHG Affiliate Token info
+[ItunesSearch sharedInstance].affiliateToken = @"xxx";
 
 // Get artist info
 [[ItunesSearch sharedInstance] getAlbumsForArtist:@"Pink Floyd" limitOrNil:@20 successHandler:^(NSArray *result) {

--- a/iTunesSearch/ItunesSearch.h
+++ b/iTunesSearch/ItunesSearch.h
@@ -20,8 +20,7 @@ typedef void (^ItunesSearchReturnBlockWithError)(NSError *error);
 
 @interface ItunesSearch : NSObject
 
-@property (strong, nonatomic) NSString *partnerId;
-@property (strong, nonatomic) NSString *tradeDoublerId;
+@property (strong, nonatomic) NSString *affiliateToken;
 @property (strong, nonatomic) NSString *countryCode;    // default: NSLocaleCountryCode
 @property (unsafe_unretained, nonatomic) id <ItunesSearchCache> cacheDelegate;
 @property (nonatomic) NSTimeInterval timeoutInterval;   // default: 10

--- a/iTunesSearch/ItunesSearch.m
+++ b/iTunesSearch/ItunesSearch.m
@@ -29,8 +29,7 @@
 - (id)init {
     self = [super init];
     if (self) {
-        self.partnerId = @"";
-        self.tradeDoublerId = @"";
+        self.affiliateToken = @"";
         self.queue = [[NSOperationQueue alloc] init];
         self.timeoutInterval = 10;
         self.maxCacheAge = (60 * 60 * 24);
@@ -42,7 +41,7 @@
 
 - (NSString *)md5sumFromString:(NSString *)string {
 	unsigned char digest[CC_MD5_DIGEST_LENGTH], i;
-	CC_MD5([string UTF8String], [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], digest);
+	CC_MD5([string UTF8String], (CC_LONG)[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], digest);
 	NSMutableString *ms = [NSMutableString string];
 	for (i=0;i<CC_MD5_DIGEST_LENGTH;i++) {
 		[ms appendFormat: @"%02x", (int)(digest[i])];
@@ -93,11 +92,9 @@
 
     NSMutableDictionary *newParams = [params mutableCopy];
 
-    // Add affiliate identifiers if supplied
-    if (self.partnerId && self.partnerId.length > 0)
-        newParams[@"partnerId"] = self.partnerId;
-    if (self.tradeDoublerId && self.tradeDoublerId.length > 0)
-        newParams[@"tduid"] = self.tradeDoublerId;
+    // Add affiliate token if supplied
+    if (self.affiliateToken && self.affiliateToken.length > 0)
+        newParams[@"at"] = self.affiliateToken;
 
     // Set the user's country to get the correct price
     if (self.countryCode && self.countryCode.length) {


### PR DESCRIPTION
See http://www.apple.com/itunes/affiliates/resources/phg-transition.html for more info.
- Replaced partnerId and tradeDoublerId properties with a single affiliateToken property.
- Added explicit CC_LONG cast to suppress warning when compiling for 64-bit.
- Added to contributor list, and updated README to reflect changes to affiliate token properties.
